### PR TITLE
Unable to upload to directories outside of the ssh users home dir

### DIFF
--- a/lib/sftp-upload.js
+++ b/lib/sftp-upload.js
@@ -69,7 +69,7 @@ SftpUpload.prototype.uploadFiles = function(files, opt){
             function(cb){
                 var localFile = path.relative(opt.path, file),
                     remoteFile = path.join(opt.remoteDir, localFile);
-                client.upload(file, '.'+remoteFile, function(err){
+                client.upload(file, remoteFile, function(err){
                     pendingFiles += 1;
                     self.emit('uploading', {
                         file: file,


### PR DESCRIPTION
Can't upload to any folder outside of users home directory, for example if I wanted to copy files to a remote path of `/var/www/`.