### PR TITLE
Add an option to exclude folders from upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ You must configure the sftp before attempting to upload files. The following par
 - **username:** sftp server's username.
 - **path:** Location of the directory that is going to be uploaded to the server.
 - **remoteDir:** Remote directory where files are going to be uploaded.
+- **excludedFolders:** Array of directory names that won't be uploaded.
 - **privateKey:** RSA key, you must upload a public key to the remote server before attempting to upload any content.
 - **passphrase:** RSA key passphrase. (Optional, should be stored in external file)
 
@@ -28,6 +29,7 @@ You must configure the sftp before attempting to upload files. The following par
         username:'root',
         path: '/',
         remoteDir: '/tempDir',
+        excludedFolders: ['./.git', 'node_modules'],
         privateKey: fs.readFileSync('privateKey_rsa'),
 	passphrase: fs.readFileSync('privateKey_rsa.passphrase')
     },

--- a/lib/sftp-upload.js
+++ b/lib/sftp-upload.js
@@ -15,7 +15,8 @@ function SftpUpload (options){
         host: '',
         privateKey: '',
         path: '/',
-        remoteDir: '/sftpUpload-tmp-01'
+        remoteDir: '/sftpUpload-tmp-01',
+        excludedFolders: []
     }
 
     this.uploads = [];
@@ -53,7 +54,14 @@ SftpUpload.prototype.addDirectory = function(files, baseDir, uploads){
 
         if(stats.isDirectory()){
             var workingFolder = path.resolve(baseDir, currentFile);
-            self.addDirectory(fs.readdirSync(workingFolder), workingFolder, uploads);
+
+            var excludedFolderFound = self.defaults.excludedFolders.find((folder) => {
+                return path.resolve(process.cwd(), folder) === workingFolder;
+            });
+
+            if (excludedFolderFound === undefined) {
+                self.addDirectory(fs.readdirSync(workingFolder), workingFolder, uploads);
+            }
         }
     });
 }


### PR DESCRIPTION
This PR add an option to exclude folder(s) from being uploaded to the server. It can be useful if you don't want to upload some programmation artifacts for example.