### PR TITLE
Allow "path" to be an array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You must configure the sftp before attempting to upload files. The following par
 - **port:** sftp port, 22 by default.
 - **username:** sftp server's username.
 - **path:** Path to a directory or a file that is going to be uploaded to the server. String or Array.
+- **basePath:** Optional. E.g. in case if you have `path: ['./public/css','./public/js']` but want to move them directly to a `remoteDir` without creating `public` directory, you may also set `basePath: './public'` to ignore this part of the path. If your `path` is a string path to a directory, it's set as a `basePath` by default.
 - **remoteDir:** Remote directory where files are going to be uploaded.
 - **excludedFolders:** Array of directory names that won't be uploaded.
 - **privateKey:** RSA key, you must upload a public key to the remote server before attempting to upload any content.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You must configure the sftp before attempting to upload files. The following par
 - **host:** Remote server IP/Hostname.
 - **port:** sftp port, 22 by default.
 - **username:** sftp server's username.
-- **path:** Location of the directory that is going to be uploaded to the server.
+- **path:** Path to a directory or a file that is going to be uploaded to the server. String or Array.
 - **remoteDir:** Remote directory where files are going to be uploaded.
 - **excludedFolders:** Array of directory names that won't be uploaded.
 - **privateKey:** RSA key, you must upload a public key to the remote server before attempting to upload any content.

--- a/lib/sftp-upload.js
+++ b/lib/sftp-upload.js
@@ -19,17 +19,16 @@ function SftpUpload (options){
         excludedFolders: []
     }
 
+    if(!options.path){
+        throw new Error('Parameter "path" is required');
+    }
+    
     this.uploads = [];
     this.currentFile;
 
     events.EventEmitter.call(this);
 
-    var self = this;
     this.defaults = extend(defaultOptions, options);
-       if(!fs.existsSync(self.defaults.path)){
-           var e = new Error(self.defaults.path+' does not exist');
-        self.emit('error', e);
-    }
 
     return this;
 };
@@ -67,7 +66,6 @@ SftpUpload.prototype.addDirectory = function(files, baseDir, uploads){
 }
 
 SftpUpload.prototype.addFiles = function(files, baseDir, uploads){
-    var self = this;
     files.forEach(function(file){
         var currentFile = path.resolve(baseDir, file),
             stats = fs.statSync(currentFile);
@@ -100,7 +98,7 @@ SftpUpload.prototype.uploadFiles = function(files, opt){
     files.forEach(function(file){
         fns.push(
             function(cb){
-                var localFile = path.relative(opt.path, file),
+                var localFile = path.relative('./', file),
                     remoteFile = path.join(opt.remoteDir, localFile);
                     self.setCurrentFile(localFile);
                 client.upload(file, remoteFile, function(err){
@@ -127,24 +125,27 @@ SftpUpload.prototype.uploadFiles = function(files, opt){
 SftpUpload.prototype.upload = function(){
     var self = this,
         opt = self.defaults,
-        isDirectory = false,
-        isFile = false,
-        files;
-    if (opt.path && !opt.files) {
-      isDirectory = true;
-      files = fs.readdirSync(opt.path);
-    }
-    if (opt.files) {
-      isFile = true;
-      files = opt.files;
-    }
-    if (isDirectory) {
-      this.addDirectory(files, opt.path, self.uploads);
-    } else {
-      this.addFiles(files, opt.path, self.uploads);
-    }
+        paths = typeof opt.path === 'string' ? [opt.path] : opt.path;
+
+    paths.forEach(_path_ => {
+        var currentFile = path.resolve(_path_);
+        var fileExists = fs.existsSync(currentFile);
+        if(fileExists){
+            var stats = fs.statSync(currentFile);
+
+            if(stats.isFile()){
+                self.uploads.push(currentFile);
+            } else {
+                var files = fs.readdirSync(_path_);
+                this.addDirectory(files, _path_, self.uploads);
+            }
+        } else {
+            console.log(currentFile + ' - does not exist');
+        }
+    });
 
     this.uploadFiles(self.uploads, opt);
+    
     return this;
 };
 

--- a/lib/sftp-upload.js
+++ b/lib/sftp-upload.js
@@ -15,6 +15,7 @@ function SftpUpload (options){
         host: '',
         privateKey: '',
         path: '/',
+        basePath: './',
         remoteDir: '/sftpUpload-tmp-01',
         excludedFolders: []
     }
@@ -29,6 +30,9 @@ function SftpUpload (options){
     events.EventEmitter.call(this);
 
     this.defaults = extend(defaultOptions, options);
+    if(typeof this.defaults.path === 'string') {
+        this.defaults.basePath = this.defaults.path;
+    }
 
     return this;
 };
@@ -98,7 +102,7 @@ SftpUpload.prototype.uploadFiles = function(files, opt){
     files.forEach(function(file){
         fns.push(
             function(cb){
-                var localFile = path.relative('./', file),
+                var localFile = path.relative(opt.basePath, file),
                     remoteFile = path.join(opt.remoteDir, localFile);
                     self.setCurrentFile(localFile);
                 client.upload(file, remoteFile, function(err){


### PR DESCRIPTION
Previous:

    path: './sample/',

Updated:

    path: [
        './sample/',
        './file.js',
        '..r',   // not existing files are just ignored and skipped
    ],