### PR TITLE
fix(Auth): enable password only auth and fallback to passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You must configure the sftp before attempting to upload files. The following par
 - **exclude:** Array of specific relative file names that won't be uploaded.
 - **privateKey:** RSA key, you must upload a public key to the remote server before attempting to upload any content.
 - **passphrase:** RSA key passphrase. (Optional, should be stored in external file)
+- **password:** When using username password only authentication (Optional)
 - **dryRun:** Just list files to be uploaded, don't actually send anything to the server.
 
 ### Example

--- a/lib/sftp-upload.js
+++ b/lib/sftp-upload.js
@@ -25,6 +25,10 @@ function SftpUpload (options){
     if(!options.path){
         throw new Error('Parameter "path" is required');
     }
+
+    if (typeof options.passphrase === 'string') {
+        options.password = options.passphrase
+    }
     
     this.uploads = [];
     this.currentFile;


### PR DESCRIPTION
Got some errors trying to connect to a webhost sftp connection. Found out the password field was used by ssh2. Added this to the README and added a fallback that would take care of the confusion between the two fields